### PR TITLE
添加Linux/Mac下使用的调试脚本

### DIFF
--- a/script/start_debug_LinuxMac.sh
+++ b/script/start_debug_LinuxMac.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# 定义要启动的Go文件路径列表
+files=(
+    "service/content/rpc/content.go"
+    "service/user/rpc/user.go"
+    "service/media/rpc/media.go"
+    "service/chat/rpc/chat.go"
+
+    "service/user/api/user.go"
+    "service/content/api/content.go"
+    "service/media/api/media.go"
+    "service/chat/api/chat.go"
+
+    "consumer/uploadConsumer/main.go"
+    "consumer/loginConsumer/main.go"
+    "job/main.go"
+)
+
+rm -rf debug_log
+mkdir debug_log
+
+# 循环启动Go文件并将输出写入独立的文件
+for file in "${files[@]}"
+do
+    echo "启动服务: $file"
+    output_file="debug_log/$(echo "$file" | awk -F/ '{print $(NF-1),$NF}' | cut -d. -f1 | awk '{print $1"_"$2}').log"
+    # 创建output_file 文件
+    echo "$output_file"
+    touch $output_file
+    nohup go run "$file" > "$output_file" 2>&1 &
+    sleep 5
+done
+
+# 等待所有进程结束
+wait


### PR DESCRIPTION
仅针对Linux/Mac用户

一、使用方法：
在项目根目录下，执行`sh script/start_debug_LinuxMac.sh`

二、使用效果：
项目根目录下自动生成`/debug_log`文件夹和对应的main函数输出到终端的日志
<img width="245" alt="image" src="https://github.com/SixSteeds/SimpleDouyinLiuJun/assets/25169930/b8374972-cca7-45ca-948c-a3d3457f5b61">

